### PR TITLE
Fix modulo not working for floating values

### DIFF
--- a/core/Number_Field.php
+++ b/core/Number_Field.php
@@ -77,7 +77,7 @@ class Number_Field extends Field {
 
 		if ( $this->step !== null ) {
 			$step_base = ( $this->min !== null ) ? $this->min : 0;
-			$is_valid_step_value = ( $value - $step_base ) % $this->step === 0;
+			$is_valid_step_value = fmod( ( $value - $step_base ), $this->step ) === 0;
 			if ( ! $is_valid_step_value ) {
 				$value = $step_base; // value is not valid - reset it to a base value
 			}


### PR DESCRIPTION
Also fixes PHP error `DivisionByZeroError` thrown by the % operator when the 2nd value is `0.1` for example