### PR TITLE
Fix the logic for validating current value by step

### DIFF
--- a/core/Number_Field.php
+++ b/core/Number_Field.php
@@ -76,10 +76,17 @@ class Number_Field extends Field {
 		}
 
 		if ( $this->step !== null ) {
-			$step_base = ( $this->min !== null ) ? $this->min : 0;
-			$is_valid_step_value = ( $value - $step_base ) % $this->step === 0;
-			if ( ! $is_valid_step_value ) {
-				$value = $step_base; // value is not valid - reset it to a base value
+			$min = ( $this->min !== null ) ? $this->min : 0;
+			// Base Formula "value = min + n * step" where "n" should be integer
+			$test_for_step_validation = ( $value - $min ) / $this->step;
+
+			$test_for_step_validation_floored = floor( $test_for_step_validation );
+
+			// bccom is required when comparing two floating numbers, since the regular "==" fails here
+			$is_valid_step = bccomp( $test_for_step_validation, $test_for_step_validation_floored ) === 0;
+
+			if ( ! $is_valid_step ) {
+				$value = $min; // value is not valid - reset it to a base value
 			}
 		}
 

--- a/core/Number_Field.php
+++ b/core/Number_Field.php
@@ -77,13 +77,11 @@ class Number_Field extends Field {
 
 		if ( $this->step !== null ) {
 			$min = ( $this->min !== null ) ? $this->min : 0;
+
 			// Base Formula "value = min + n * step" where "n" should be integer
 			$test_for_step_validation = ( $value - $min ) / $this->step;
 
-			$test_for_step_validation_floored = floor( $test_for_step_validation );
-
-			// bccom is required when comparing two floating numbers, since the regular "==" fails here
-			$is_valid_step = bccomp( $test_for_step_validation, $test_for_step_validation_floored ) === 0;
+			$is_valid_step = strpos( strval( $test_for_step_validation ), '.' ) === false;
 
 			if ( ! $is_valid_step ) {
 				$value = $min; // value is not valid - reset it to a base value


### PR DESCRIPTION
The previous code only works with integer steps,  and does not account that modulo operator fails with `0.1` as the 2nd parameter.
The `fmod` also fails, by returning non-zero when `0` is expected.

Explanation:
https://stackoverflow.com/questions/3148937/compare-floats-in-php
https://stackoverflow.com/questions/32996034/fmod-returning-incorrect-result